### PR TITLE
Avoid warning on continue inside switch

### DIFF
--- a/Classes/PHPExcel/Shared/OLE.php
+++ b/Classes/PHPExcel/Shared/OLE.php
@@ -285,7 +285,7 @@ class PHPExcel_Shared_OLE
                     $pps = new PHPExcel_Shared_OLE_PPS_File($name);
                     break;
                 default:
-                    continue;
+                    continue 2;
             }
             fseek($fh, 1, SEEK_CUR);
             $pps->Type    = $type;


### PR DESCRIPTION
Since php 7.3 a continue inside a switch is treatead as a break and generates a warning.
To prevent this and make the continue skip the foreach loop the argument  must be passed.